### PR TITLE
Aborts the run of the compressor if it will lead to more rows in the database

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ pub fn run(mut config: Config) {
     );
 
     if ratio > 1.0 {
-        println!("This compression would not remove any rows. Aborting.");
+        println!("This compression would not remove any rows. Exiting.");
         return;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,11 @@ pub fn run(mut config: Config) {
         compressor.stats.state_groups_changed
     );
 
+    if ratio > 1.0 {
+        println!("This compression would not remove any rows. Aborting.");
+        return;
+    }
+
     if let Some(min) = config.min_saved_rows {
         let saving = (original_summed_size - compressed_summed_size) as i32;
         if saving < min {


### PR DESCRIPTION
BUILDS ON azren/all_options_readme_and_help

This aborts the run of the compressor if it will lead to MORE rows in the database

This will prevent accidently running the generated SQL on the database and increasing storage requirements.
