### PR TITLE
Move the graph generation to before early exit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,10 @@ pub fn run(mut config: Config) {
         compressor.stats.state_groups_changed
     );
 
+    if config.graphs {
+        graphing::make_graphs(&state_group_map, new_state_group_map);
+    }
+
     if ratio > 1.0 {
         println!("This compression would not remove any rows. Exiting.");
         return;
@@ -381,10 +385,6 @@ pub fn run(mut config: Config) {
             &state_group_map,
             new_state_group_map,
         );
-    }
-
-    if config.graphs {
-        graphing::make_graphs(&state_group_map, new_state_group_map);
     }
 }
 


### PR DESCRIPTION
BUILDS ON azren/continuing_run

Moved the graph generation to before early exit
    
If the tool is making the tables bigger than they were before then
the compressor aborts the run. However if you wanted to debug this
by looking at before and after graphs of the chunk being compressed
then these need to be generated before it exits early. 