### PR TITLE
Move setting up jemalloc out of library crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,6 @@
 
 use pyo3::{exceptions, prelude::*};
 
-#[cfg(feature = "jemalloc")]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use clap::{crate_authors, crate_description, crate_name, crate_version, value_t, App, Arg};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@
 //! Synapse instance's database. Specifically, it aims to reduce the number of
 //! rows that a given room takes up in the `state_groups_state` table.
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use synapse_compress_state as comp_state;
 
 fn main() {


### PR DESCRIPTION
This enables other packages to use the compressor without jemalloc