### PR TITLE
Don't panic in continue_run if no groups found within range  

### DIFF
--- a/compressor_integration_tests/tests/compressor_continue_run_tests.rs
+++ b/compressor_integration_tests/tests/compressor_continue_run_tests.rs
@@ -30,7 +30,7 @@ fn continue_run_called_twice_same_as_run() {
     let room_id = "room1".to_string();
 
     // will run the compression in two batches
-    let start = -1;
+    let start = None;
     let chunk_size = 7;
 
     // compress in 3,3 level sizes
@@ -38,7 +38,7 @@ fn continue_run_called_twice_same_as_run() {
     let level_info = vec![Level::restore(3, 0, None), Level::restore(3, 0, None)];
 
     // Run the compressor with those settings
-    let chunk_stats_1 = continue_run(start, chunk_size, &db_url, &room_id, &level_info);
+    let chunk_stats_1 = continue_run(start, chunk_size, &db_url, &room_id, &level_info).unwrap();
 
     // Assert that it stopped at 6 (i.e. after the 7 groups 0...6)
     assert_eq!(chunk_stats_1.last_compressed_group, 6);
@@ -53,12 +53,12 @@ fn continue_run_called_twice_same_as_run() {
         vec![Level::restore(3, 1, Some(6)), Level::restore(3, 2, Some(6))]
     );
 
-    let start = 6;
+    let start = Some(6);
     let chunk_size = 7;
     let level_info = chunk_stats_1.new_level_info.clone();
 
     // Run the compressor with those settings
-    let chunk_stats_2 = continue_run(start, chunk_size, &db_url, &room_id, &level_info);
+    let chunk_stats_2 = continue_run(start, chunk_size, &db_url, &room_id, &level_info).unwrap();
 
     // Assert that it stopped at 7
     assert_eq!(chunk_stats_2.last_compressed_group, 13);

--- a/src/compressor/compressor_tests.rs
+++ b/src/compressor/compressor_tests.rs
@@ -677,11 +677,11 @@ fn get_delta_returns_snapshot_if_no_prev_possible() {
     let mut levels_iter = compressor.levels.iter_mut();
 
     let l1 = levels_iter.next().unwrap();
-    l1.current = Some(3);
+    l1.head = Some(3);
     l1.current_chain_length = 1;
 
     let l2 = levels_iter.next().unwrap();
-    l2.current = Some(3);
+    l2.head = Some(3);
     l2.current_chain_length = 1;
 
     // Now try and find delta for 4 with 3 as pred

--- a/src/compressor/level_tests.rs
+++ b/src/compressor/level_tests.rs
@@ -5,7 +5,7 @@ fn new_produces_empty_level() {
     let l = Level::new(15);
     assert_eq!(l.max_length, 15);
     assert_eq!(l.current_chain_length, 0);
-    assert_eq!(l.current, None);
+    assert_eq!(l.head, None);
 }
 
 #[test]
@@ -14,7 +14,7 @@ fn update_adds_to_non_full_level() {
     l.update(7, true);
     assert_eq!(l.max_length, 10);
     assert_eq!(l.current_chain_length, 1);
-    assert_eq!(l.current, Some(7));
+    assert_eq!(l.head, Some(7));
 }
 
 #[test]
@@ -40,15 +40,15 @@ fn update_resets_level_correctly() {
     l.update(6, false);
     assert_eq!(l.max_length, 5);
     assert_eq!(l.current_chain_length, 1);
-    assert_eq!(l.current, Some(6));
+    assert_eq!(l.head, Some(6));
 }
 
 #[test]
-fn get_current_returns_current() {
+fn get_head_returns_head() {
     let mut l = Level::new(5);
-    assert_eq!(l.get_current(), None);
+    assert_eq!(l.get_head(), None);
     l.update(23, true);
-    assert_eq!(l.get_current(), Some(23));
+    assert_eq!(l.get_head(), Some(23));
 }
 
 #[test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -126,10 +126,7 @@ pub fn reload_data_from_db(
 /// * `levels'  -   The levels who's heads are being requested
 fn load_level_heads(client: &mut Client, level_info: &[Level]) -> BTreeMap<i64, StateGroupEntry> {
     // obtain all of the heads that aren't None from level_info
-    let level_heads: Vec<i64> = level_info
-        .iter()
-        .filter_map(|l| (*l).get_current())
-        .collect();
+    let level_heads: Vec<i64> = level_info.iter().filter_map(|l| (*l).get_head()).collect();
 
     // Query to get id, predecessor and deltas for each state group
     let sql = r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,6 @@
 
 use pyo3::{exceptions, prelude::*};
 
-#[cfg(feature = "jemalloc")]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use clap::{crate_authors, crate_description, crate_name, crate_version, value_t, App, Arg};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@
 //! Synapse instance's database. Specifically, it aims to reduce the number of
 //! rows that a given room takes up in the `state_groups_state` table.
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use synapse_compress_state as comp_state;
 
 fn main() {


### PR DESCRIPTION
Also allow `groups_to_compress` to be used if `min_state_group` is None
(previously had to set it to something like -1 which was ugly)