### PR TITLE
Add method that compresses the chunks with lowest uncompressed state_group ids

### DIFF
--- a/auto_compressor/Cargo.toml
+++ b/auto_compressor/Cargo.toml
@@ -27,4 +27,4 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies.pyo3]
 version = "0.14.1"
-features = ["extension-module","abi3-py36"] 
+features = ["extension-module","abi3-py36"]

--- a/auto_compressor/src/manager.rs
+++ b/auto_compressor/src/manager.rs
@@ -199,20 +199,11 @@ pub fn compress_largest_rooms(
         Err(e) => bail!("Error while connecting to {}: {}", db_url, e),
     };
 
-    if let Err(e) = create_tables_if_needed(&mut client) {
-        bail!(
-            "Error while attempting to create state compressor tables: {}",
-            e
-        );
-    }
+    create_tables_if_needed(&mut client)
+        .with_context(|| "Failed to create state compressor tables")?;
 
-    let rooms_to_compress = match get_rooms_with_most_rows_to_compress(&mut client, number) {
-        Ok(r) => r,
-        Err(e) => bail!(
-            "Error while trying to work out what room to compress next: {}",
-            e
-        ),
-    };
+    let rooms_to_compress = get_rooms_with_most_rows_to_compress(&mut client, number)
+        .with_context(|| "Failed to work out what room to compress next")?;
 
     if rooms_to_compress.is_none() {
         return Ok(());

--- a/auto_compressor/src/manager.rs
+++ b/auto_compressor/src/manager.rs
@@ -2,7 +2,7 @@
 // of compression on the database.
 
 use crate::state_saving::{
-    connect_to_database, create_tables_if_needed, get_rooms_with_most_rows_to_compress,
+    connect_to_database, create_tables_if_needed, get_next_room_to_compress,
     read_room_compressor_state, write_room_compressor_state,
 };
 use anyhow::{bail, Context, Result};
@@ -112,10 +112,7 @@ pub fn run_compressor_on_room_chunk(
     Ok(Some(chunk_stats))
 }
 
-/// Compresses a chunk of the 1st room in the rooms_to_compress argument given
-///
-/// If the 1st room has no more groups to compress then it
-/// removes that room from the rooms_to_compress vector
+/// Runs the compressor in chunks on rooms with the lowest uncompressed state group ids
 ///
 /// # Arguments
 ///
@@ -135,63 +132,13 @@ pub fn run_compressor_on_room_chunk(
 ///                         on what sort of compression structure we want. The default that
 ///                         the library suggests is empty levels with max sizes of 100, 50 and 25
 ///
-/// * `rooms_to_compress` - A vector of (room_id, number of uncompressed rows) tuples. This is a
-///                         list of all the rooms that need compressing
-fn compress_chunk_of_first_room(
+/// * `number_of_chunks`-   The number of chunks to compress. The larger this number is, the longer
+///                         the compressor will run for.
+pub fn compress_chunks_of_database(
     db_url: &str,
     chunk_size: i64,
     default_levels: &[Level],
-    rooms_to_compress: &mut Vec<(String, i64)>,
-) -> Result<Option<ChunkStats>> {
-    if rooms_to_compress.is_empty() {
-        bail!("Called compress_chunk_of_first_room with empty rooms_to_compress argument");
-    }
-
-    // can call unwrap safely as have checked that rooms_to_compress is not empty
-    let (room_id, _) = rooms_to_compress.get(0).unwrap().clone();
-
-    debug!(
-        "Running compressor on room {} with chunk size {}",
-        room_id, chunk_size
-    );
-
-    let work_done = run_compressor_on_room_chunk(db_url, &room_id, chunk_size, default_levels)?;
-
-    if work_done.is_none() {
-        rooms_to_compress.remove(0);
-    }
-
-    Ok(work_done)
-}
-
-/// Runs the compressor (in chunks) on the rooms with the most uncompressed state
-///
-/// # Arguments
-///
-/// * `db_url`          -   The URL of the postgres database that synapse is using.
-///                         e.g. "postgresql://user:password@domain.com/synapse"
-///
-/// * `chunk_size`      -   The number of state_groups to work on. All of the entries
-///                         from state_groups_state are requested from the database
-///                         for state groups that are worked on. Therefore small
-///                         chunk sizes may be needed on machines with low memory.
-///                         (Note: if the compressor fails to find space savings on the
-///                         chunk as a whole (which may well happen in rooms with lots
-///                         of backfill in) then the entire chunk is skipped.)
-///
-/// * `default_levels`  -   If the compressor has never been run on this room before
-///                         Then we need to provide the compressor with some information
-///                         on what sort of compression structure we want. The default that
-///                         the library suggests is empty levels with max sizes of 100, 50 and 25
-///
-/// * `number`          -   The number of rooms to compress. The larger this number is, the more
-///                         work that can be done before having to scan through the database again
-///                         to cound the uncompressed rows
-pub fn compress_largest_rooms(
-    db_url: &str,
-    chunk_size: i64,
-    default_levels: &[Level],
-    number: i64,
+    number_of_chunks: i64,
 ) -> Result<()> {
     // connect to the database
     let mut client = match connect_to_database(db_url) {
@@ -202,56 +149,49 @@ pub fn compress_largest_rooms(
     create_tables_if_needed(&mut client)
         .with_context(|| "Failed to create state compressor tables")?;
 
-    let rooms_to_compress = get_rooms_with_most_rows_to_compress(&mut client, number)
-        .with_context(|| "Failed to work out what room to compress next")?;
-
-    if rooms_to_compress.is_none() {
-        return Ok(());
-    }
-
-    // can unwrap safely as have checked is not None
-    let mut rooms_to_compress = rooms_to_compress.unwrap();
-
     let mut skipped_chunks = 0;
     let mut rows_saved = 0;
     let mut chunks_processed = 0;
-    let mut first_chunk = true;
 
-    while !rooms_to_compress.is_empty() {
-        if first_chunk {
-            // can unwrap as have checked rooms_to_compress is not empty
-            info!(
-                "Compressing: {}, which has {} uncompressed rows",
-                rooms_to_compress.get(0).unwrap().0,
-                rooms_to_compress.get(0).unwrap().1
-            );
-            first_chunk = false;
+    while chunks_processed < number_of_chunks {
+        let room_to_compress = get_next_room_to_compress(&mut client)
+            .with_context(|| "Failed to work out what room to compress next")?;
+
+        if room_to_compress.is_none() {
+            break;
         }
 
-        let work_done = compress_chunk_of_first_room(
-            db_url,
-            chunk_size,
-            default_levels,
-            &mut rooms_to_compress,
-        )?;
+        let room_to_compress =
+            room_to_compress.expect("Have checked that rooms_to_compress is not None");
+
+        info!(
+            "Running compressor on room {} with chunk size {}",
+            room_to_compress, chunk_size
+        );
+
+        let work_done =
+            run_compressor_on_room_chunk(db_url, &room_to_compress, chunk_size, default_levels)?;
 
         if let Some(ref chunk_stats) = work_done {
             if chunk_stats.commited {
+                let savings = chunk_stats.original_num_rows - chunk_stats.new_num_rows;
                 rows_saved += chunk_stats.original_num_rows - chunk_stats.new_num_rows;
+                debug!("Saved {} rows for room {}", savings, room_to_compress);
             } else {
                 skipped_chunks += 1;
+                debug!(
+                    "Unable to make savings for room {}, skipping chunk",
+                    room_to_compress
+                );
             }
             chunks_processed += 1;
         } else {
-            info!(
-                "Finished compressing room. Saved {} rows. Skipped {}/{} chunks",
-                rows_saved, skipped_chunks, chunks_processed
-            );
-            skipped_chunks = 0;
-            rows_saved = 0;
-            chunks_processed = 0;
-            first_chunk = true;
+            bail!("Ran the compressor on a room that had no more work to do!")
         }
     }
+    info!(
+        "Finished running compressor. Saved {} rows. Skipped {}/{} chunks",
+        rows_saved, skipped_chunks, chunks_processed
+    );
     Ok(())
 }

--- a/auto_compressor/src/manager.rs
+++ b/auto_compressor/src/manager.rs
@@ -2,10 +2,11 @@
 // of compression on the database.
 
 use crate::state_saving::{
-    connect_to_database, read_room_compressor_state, write_room_compressor_state,
+    connect_to_database, create_tables_if_needed, get_rooms_with_most_rows_to_compress,
+    read_room_compressor_state, write_room_compressor_state,
 };
-use anyhow::{Context, Result};
-use log::{debug, warn};
+use anyhow::{bail, Context, Result};
+use log::{debug, info, warn};
 use synapse_compress_state::{continue_run, ChunkStats, Level};
 
 /// Runs the compressor on a chunk of the room
@@ -109,4 +110,157 @@ pub fn run_compressor_on_room_chunk(
     })?;
 
     Ok(Some(chunk_stats))
+}
+
+/// Compresses a chunk of the 1st room in the rooms_to_compress argument given
+///
+/// If the 1st room has no more groups to compress then it
+/// removes that room from the rooms_to_compress vector
+///
+/// # Arguments
+///
+/// * `db_url`          -   The URL of the postgres database that synapse is using.
+///                         e.g. "postgresql://user:password@domain.com/synapse"
+///
+/// * `chunk_size`      -   The number of state_groups to work on. All of the entries
+///                         from state_groups_state are requested from the database
+///                         for state groups that are worked on. Therefore small
+///                         chunk sizes may be needed on machines with low memory.
+///                         (Note: if the compressor fails to find space savings on the
+///                         chunk as a whole (which may well happen in rooms with lots
+///                         of backfill in) then the entire chunk is skipped.)
+///
+/// * `default_levels`  -   If the compressor has never been run on this room before
+///                         Then we need to provide the compressor with some information
+///                         on what sort of compression structure we want. The default that
+///                         the library suggests is empty levels with max sizes of 100, 50 and 25
+///
+/// * `rooms_to_compress` - A vector of (room_id, number of uncompressed rows) tuples. This is a
+///                         list of all the rooms that need compressing
+fn compress_chunk_of_first_room(
+    db_url: &str,
+    chunk_size: i64,
+    default_levels: &[Level],
+    rooms_to_compress: &mut Vec<(String, i64)>,
+) -> Result<Option<ChunkStats>> {
+    if rooms_to_compress.is_empty() {
+        bail!("Called compress_chunk_of_first_room with empty rooms_to_compress argument");
+    }
+
+    // can call unwrap safely as have checked that rooms_to_compress is not empty
+    let (room_id, _) = rooms_to_compress.get(0).unwrap().clone();
+
+    debug!(
+        "Running compressor on room {} with chunk size {}",
+        room_id, chunk_size
+    );
+
+    let work_done = run_compressor_on_room_chunk(db_url, &room_id, chunk_size, default_levels)?;
+
+    if work_done.is_none() {
+        rooms_to_compress.remove(0);
+    }
+
+    Ok(work_done)
+}
+
+/// Runs the compressor (in chunks) on the rooms with the most uncompressed state
+///
+/// # Arguments
+///
+/// * `db_url`          -   The URL of the postgres database that synapse is using.
+///                         e.g. "postgresql://user:password@domain.com/synapse"
+///
+/// * `chunk_size`      -   The number of state_groups to work on. All of the entries
+///                         from state_groups_state are requested from the database
+///                         for state groups that are worked on. Therefore small
+///                         chunk sizes may be needed on machines with low memory.
+///                         (Note: if the compressor fails to find space savings on the
+///                         chunk as a whole (which may well happen in rooms with lots
+///                         of backfill in) then the entire chunk is skipped.)
+///
+/// * `default_levels`  -   If the compressor has never been run on this room before
+///                         Then we need to provide the compressor with some information
+///                         on what sort of compression structure we want. The default that
+///                         the library suggests is empty levels with max sizes of 100, 50 and 25
+///
+/// * `number`          -   The number of rooms to compress. The larger this number is, the more
+///                         work that can be done before having to scan through the database again
+///                         to cound the uncompressed rows
+pub fn compress_largest_rooms(
+    db_url: &str,
+    chunk_size: i64,
+    default_levels: &[Level],
+    number: i64,
+) -> Result<()> {
+    // connect to the database
+    let mut client = match connect_to_database(db_url) {
+        Ok(c) => c,
+        Err(e) => bail!("Error while connecting to {}: {}", db_url, e),
+    };
+
+    if let Err(e) = create_tables_if_needed(&mut client) {
+        bail!(
+            "Error while attempting to create state compressor tables: {}",
+            e
+        );
+    }
+
+    let rooms_to_compress = match get_rooms_with_most_rows_to_compress(&mut client, number) {
+        Ok(r) => r,
+        Err(e) => bail!(
+            "Error while trying to work out what room to compress next: {}",
+            e
+        ),
+    };
+
+    if rooms_to_compress.is_none() {
+        return Ok(());
+    }
+
+    // can unwrap safely as have checked is not None
+    let mut rooms_to_compress = rooms_to_compress.unwrap();
+
+    let mut skipped_chunks = 0;
+    let mut rows_saved = 0;
+    let mut chunks_processed = 0;
+    let mut first_chunk = true;
+
+    while !rooms_to_compress.is_empty() {
+        if first_chunk {
+            // can unwrap as have checked rooms_to_compress is not empty
+            info!(
+                "Compressing: {}, which has {} uncompressed rows",
+                rooms_to_compress.get(0).unwrap().0,
+                rooms_to_compress.get(0).unwrap().1
+            );
+            first_chunk = false;
+        }
+
+        let work_done = compress_chunk_of_first_room(
+            db_url,
+            chunk_size,
+            default_levels,
+            &mut rooms_to_compress,
+        )?;
+
+        if let Some(ref chunk_stats) = work_done {
+            if chunk_stats.commited {
+                rows_saved += chunk_stats.original_num_rows - chunk_stats.new_num_rows;
+            } else {
+                skipped_chunks += 1;
+            }
+            chunks_processed += 1;
+        } else {
+            info!(
+                "Finished compressing room. Saved {} rows. Skipped {}/{} chunks",
+                rows_saved, skipped_chunks, chunks_processed
+            );
+            skipped_chunks = 0;
+            rows_saved = 0;
+            chunks_processed = 0;
+            first_chunk = true;
+        }
+    }
+    Ok(())
 }

--- a/auto_compressor/src/manager.rs
+++ b/auto_compressor/src/manager.rs
@@ -141,13 +141,10 @@ pub fn compress_chunks_of_database(
     number_of_chunks: i64,
 ) -> Result<()> {
     // connect to the database
-    let mut client = match connect_to_database(db_url) {
-        Ok(c) => c,
-        Err(e) => bail!("Error while connecting to {}: {}", db_url, e),
-    };
+    let mut client = connect_to_database(db_url)
+        .with_context(|| format!("Failed to connect to database at {}", db_url))?;
 
-    create_tables_if_needed(&mut client)
-        .with_context(|| "Failed to create state compressor tables")?;
+    create_tables_if_needed(&mut client).context("Failed to create state compressor tables")?;
 
     let mut skipped_chunks = 0;
     let mut rows_saved = 0;
@@ -155,7 +152,7 @@ pub fn compress_chunks_of_database(
 
     while chunks_processed < number_of_chunks {
         let room_to_compress = get_next_room_to_compress(&mut client)
-            .with_context(|| "Failed to work out what room to compress next")?;
+            .context("Failed to work out what room to compress next")?;
 
         if room_to_compress.is_none() {
             break;

--- a/auto_compressor/src/state_saving.rs
+++ b/auto_compressor/src/state_saving.rs
@@ -292,14 +292,13 @@ pub fn get_next_room_to_compress(client: &mut Client) -> Result<Option<String>> 
         LIMIT 1
     "#;
 
-    let rows = client.query(get_next_room, &[])?;
+    let row_opt = client.query_opt(get_next_room, &[])?;
 
-    // If there is nothing left to compress then no rows are returned
-    if rows.is_empty() {
+    let next_room_row = if let Some(row) = row_opt {
+        row
+    } else {
         return Ok(None);
-    }
-
-    let next_room_row = rows.get(0).expect("Have checked that rows is not empty");
+    };
 
     let next_room: String = next_room_row.get("room_id");
     let lowest_uncompressed_group: i64 = next_room_row.get("id");

--- a/compressor_integration_tests/src/lib.rs
+++ b/compressor_integration_tests/src/lib.rs
@@ -314,6 +314,7 @@ pub fn clear_compressor_state() {
     let sql = r"
         TRUNCATE state_compressor_state;
         TRUNCATE state_compressor_progress;
+        UPDATE state_compressor_total_progress SET lowest_uncompressed_group = 0;
     ";
 
     client.batch_execute(sql).unwrap();

--- a/compressor_integration_tests/tests/auto_compressor_manager_tests.rs
+++ b/compressor_integration_tests/tests/auto_compressor_manager_tests.rs
@@ -1,15 +1,21 @@
+use std::collections::BTreeMap;
+
 use auto_compressor::{
-    manager::run_compressor_on_room_chunk,
+    manager::{compress_largest_rooms, run_compressor_on_room_chunk},
     state_saving::{connect_to_database, create_tables_if_needed},
 };
 use compressor_integration_tests::{
     add_contents_to_database, clear_compressor_state, database_collapsed_states_match_map,
     database_structure_matches_map, empty_database,
-    map_builder::{compressed_3_3_from_0_to_13_with_state, line_segments_with_state},
+    map_builder::{
+        compressed_3_3_from_0_to_13_with_state, line_segments_with_state,
+        structure_from_edges_with_state,
+    },
     setup_logger, DB_URL,
 };
 use serial_test::serial;
-use synapse_compress_state::Level;
+use state_map::StateMap;
+use synapse_compress_state::{Level, StateGroupEntry};
 
 #[test]
 #[serial(db)]
@@ -31,7 +37,7 @@ fn run_compressor_on_room_chunk_works() {
     clear_compressor_state();
 
     // compress in 3,3 level sizes by default
-    let default_levels = vec![Level::restore(3, 0, None), Level::restore(3, 0, None)];
+    let default_levels = vec![Level::new(3), Level::new(3)];
 
     // compress the first 7 groups in the room
     // structure should be the following afterwards
@@ -62,4 +68,291 @@ fn run_compressor_on_room_chunk_works() {
 
     // Check that the structure of the database matches the expected structure
     assert!(database_structure_matches_map(&expected));
+}
+
+#[test]
+#[serial(db)]
+fn compress_largest_rooms_compresses_multiple_rooms() {
+    setup_logger();
+    // This creates 2 with the following structure
+    //
+    // 0-1-2 3-4-5 6-7-8 9-10-11 12-13
+    // (with room2's numbers shifted up 14)
+    //
+    // Each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i in that room
+    let initial1 = line_segments_with_state(0, 13);
+    let initial2 = line_segments_with_state(14, 27);
+
+    empty_database();
+    add_contents_to_database("room1", &initial1);
+    add_contents_to_database("room2", &initial2);
+
+    let mut client = connect_to_database(DB_URL).unwrap();
+    create_tables_if_needed(&mut client).unwrap();
+    clear_compressor_state();
+
+    // compress in 3,3 level sizes by default
+    let default_levels = vec![Level::new(3), Level::new(3)];
+
+    // compress the largest 10 rooms in chunks of size 7
+    // (Note only 2 rooms should exist in the database, but this should not panic)
+    compress_largest_rooms(DB_URL, 7, &default_levels, 10).unwrap();
+
+    // We are aiming for the following structure in the database for room1
+    // i.e. groups 6 and 9 should have changed from initial map
+    // N.B. this saves 11 rows
+    //
+    // 0  3\      12
+    // 1  4 6\    13
+    // 2  5 7 9
+    //      8 10
+    //        11
+    //
+    // Where each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i
+    let expected1 = compressed_3_3_from_0_to_13_with_state();
+
+    // Check that the database still gives correct states for each group in room1
+    assert!(database_collapsed_states_match_map(&initial1));
+
+    // Check that the structure of the database matches the expected structure for room1
+    assert!(database_structure_matches_map(&expected1));
+
+    // room 2 should have the same structure but will all numbers shifted up by 14
+    let expected_edges: BTreeMap<i64, i64> = vec![
+        (15, 14),
+        (16, 15),
+        (18, 17),
+        (19, 18),
+        (20, 17),
+        (21, 20),
+        (22, 21),
+        (23, 20),
+        (24, 23),
+        (25, 24),
+        (27, 26),
+    ]
+    .into_iter()
+    .collect();
+
+    let expected2 = structure_from_edges_with_state(expected_edges, 14, 27);
+
+    // Check that the database still gives correct states for each group in room2
+    assert!(database_collapsed_states_match_map(&initial2));
+
+    // Check that the structure of the database matches the expected structure for room2
+    assert!(database_structure_matches_map(&expected2));
+}
+
+#[test]
+#[serial(db)]
+fn compress_largest_rooms_does_largest_rooms() {
+    setup_logger();
+    // This creates 2 with the following structure
+    //
+    // 0-1-2 3-4-5 (room1)
+    // 14-15-16 17-18-19 20-21-22 23-24-25 26-27 (room2)
+    //
+    // Each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i in that room
+
+    // NOTE the second room has more state
+
+    let initial1 = line_segments_with_state(0, 5);
+    let initial2 = line_segments_with_state(14, 27);
+
+    empty_database();
+    add_contents_to_database("room1", &initial1);
+    add_contents_to_database("room2", &initial2);
+
+    let mut client = connect_to_database(DB_URL).unwrap();
+    create_tables_if_needed(&mut client).unwrap();
+    clear_compressor_state();
+
+    // compress in 3,3 level sizes by default
+    let default_levels = vec![Level::new(3), Level::new(3)];
+
+    // compress the largest 1 rooms in chunks of size 7
+    // (Note this should ONLY compress room2 since it has more state)
+    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
+
+    // We are aiming for the following structure in the database for room2
+    // i.e. groups 20 and 23 should have changed from initial map
+    // N.B. this saves 11 rows
+    //
+    // 14  17\       26
+    // 15  18 20\    27
+    // 16  19 21 23
+    //        22 24
+    //           25
+    //
+    // Where each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i in that room
+    let expected_edges: BTreeMap<i64, i64> = vec![
+        (15, 14),
+        (16, 15),
+        (18, 17),
+        (19, 18),
+        (20, 17),
+        (21, 20),
+        (22, 21),
+        (23, 20),
+        (24, 23),
+        (25, 24),
+        (27, 26),
+    ]
+    .into_iter()
+    .collect();
+
+    let expected2 = structure_from_edges_with_state(expected_edges, 14, 27);
+
+    // Check that the database still gives correct states for each group in room1
+    assert!(database_collapsed_states_match_map(&initial1));
+
+    // Check that the structure of the database is still what it was initially
+    assert!(database_structure_matches_map(&initial1));
+
+    // Check that the database still gives correct states for each group in room2
+    assert!(database_collapsed_states_match_map(&initial2));
+
+    // Check that the structure of the database is the expected compressed one
+    assert!(database_structure_matches_map(&expected2));
+}
+
+#[test]
+#[serial(db)]
+fn compress_largest_rooms_skips_already_compressed_when_rerun() {
+    setup_logger();
+    // This test builds two rooms in the database and then calls compress_largest_rooms
+    // with a number argument of 1 (i.e. only the larger of the two rooms should be
+    // compressed)
+    //
+    // It then adds another state group to the larger of the two rooms and calls the
+    // compress_largest_rooms function again. However there is more UNCOMPRESSED state
+    // in the smaller room, so the new state added to the larger room should remain
+    // untouched
+    //
+    // This is meant to simulate events happening in rooms between calls to the function
+
+    // Initially create 2 rooms with the following structure
+    //
+    // 0-1-2 3-4-5 6-7-8 9-10-11 12-13(room1)
+    // 14-15-16 17-18-19 20 (room2)
+    //
+    // Each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i in that room
+    // NOTE the first room is the larger one
+    let initial1 = line_segments_with_state(0, 13);
+    let initial2 = line_segments_with_state(14, 20);
+
+    empty_database();
+    add_contents_to_database("room1", &initial1);
+    add_contents_to_database("room2", &initial2);
+
+    let mut client = connect_to_database(DB_URL).unwrap();
+    create_tables_if_needed(&mut client).unwrap();
+    clear_compressor_state();
+
+    // compress in 3,3 level sizes by default
+    let default_levels = vec![Level::restore(3, 0, None), Level::restore(3, 0, None)];
+
+    // compress the largest 1 rooms in chunks of size 7
+    // (Note this should ONLY compress room1 since it has more state)
+    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
+
+    // This should have created the following structure in the database
+    // i.e. groups 6 and 9 should have changed from before
+    // N.B. this saves 11 rows
+    //
+    // 0  3\      12
+    // 1  4 6\    13
+    // 2  5 7 9
+    //      8 10
+    //        11
+    // room 2 should be unchanged
+    let expected1 = compressed_3_3_from_0_to_13_with_state();
+
+    // room1 is new structure, room2 is as it was initially
+    assert!(database_structure_matches_map(&expected1));
+    assert!(database_structure_matches_map(&initial2));
+
+    // Now add another state group to room1 with predecessor 12
+    //
+    // If the compressor is run on room1 again then the prev_state_group for 21
+    // will be set to 13
+    //
+    // i.e the compressor would try and build the following:
+    //
+    // 0  3\      12
+    // 1  4 6\    13
+    // 2  5 7 9   21
+    //      8 10
+    //        11
+
+    let mut initial1_with_new_group = expected1.clone();
+
+    let mut group21 = StateGroupEntry {
+        in_range: true,
+        prev_state_group: Some(12),
+        state_map: StateMap::new(),
+    };
+
+    // add in the new state for this state group
+    group21.state_map.insert("group", "13", "seen".into());
+    group21.state_map.insert("group", "21", "seen".into());
+    group21.state_map.insert("node", "is", "21".into());
+
+    initial1_with_new_group.insert(21, group21);
+
+    // Actually send this group to the database
+    let sql = r#"
+        INSERT INTO state_groups (id, room_id, event_id) VALUES (21,'room1','left_blank');
+        INSERT INTO state_group_edges (state_group, prev_state_group) VALUES 
+            (21,12);
+        INSERT INTO state_groups_state (state_group, room_id, type, state_key, event_id) VALUES
+            (21,'room1','node', 'is', '21'),
+            (21,'room1','group', '13', 'seen'),
+            (21,'room1','group', '21', 'seen');
+    "#;
+    client.batch_execute(sql).unwrap();
+
+    // We are aiming for the following structure in the database for room2
+    // i.e. only group 20 hould have changed from initial map
+    //
+    // 14  17\
+    // 15  18 20
+    // 16  19
+    //
+    // Where each group i has state:
+    //     ('node','is',      i)
+    //     ('group',  j, 'seen') - for all j less than i in that room
+    let expected_edges: BTreeMap<i64, i64> = vec![(15, 14), (16, 15), (18, 17), (19, 18), (20, 17)]
+        .into_iter()
+        .collect();
+
+    let expected2 = structure_from_edges_with_state(expected_edges, 14, 20);
+
+    // compress the largest 1 rooms in chunks of size 7
+    // (Note this should ONLY compress room2 since room1 only has 1 uncompressed state group)
+    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
+
+    // Check that the database still gives correct states for each group in room1
+    assert!(database_collapsed_states_match_map(
+        &initial1_with_new_group
+    ));
+
+    // Check that the structure of the database is still what it was befeore
+    // compress_largest_rooms was called (i.e. that pred of 21 is still 12 not now 13)
+    assert!(database_structure_matches_map(&initial1_with_new_group));
+
+    // Check that the database still gives correct states for each group in room2
+    assert!(database_collapsed_states_match_map(&initial2));
+    // Check that the structure of the database is the expected compressed one
+    assert!(database_structure_matches_map(&expected2));
 }

--- a/compressor_integration_tests/tests/auto_compressor_manager_tests.rs
+++ b/compressor_integration_tests/tests/auto_compressor_manager_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use auto_compressor::{
-    manager::{compress_largest_rooms, run_compressor_on_room_chunk},
+    manager::{compress_chunks_of_database, run_compressor_on_room_chunk},
     state_saving::{connect_to_database, create_tables_if_needed},
 };
 use compressor_integration_tests::{
@@ -14,8 +14,7 @@ use compressor_integration_tests::{
     setup_logger, DB_URL,
 };
 use serial_test::serial;
-use state_map::StateMap;
-use synapse_compress_state::{Level, StateGroupEntry};
+use synapse_compress_state::Level;
 
 #[test]
 #[serial(db)]
@@ -72,7 +71,7 @@ fn run_compressor_on_room_chunk_works() {
 
 #[test]
 #[serial(db)]
-fn compress_largest_rooms_compresses_multiple_rooms() {
+fn compress_chunks_of_database_compresses_multiple_rooms() {
     setup_logger();
     // This creates 2 with the following structure
     //
@@ -96,9 +95,9 @@ fn compress_largest_rooms_compresses_multiple_rooms() {
     // compress in 3,3 level sizes by default
     let default_levels = vec![Level::new(3), Level::new(3)];
 
-    // compress the largest 10 rooms in chunks of size 7
-    // (Note only 2 rooms should exist in the database, but this should not panic)
-    compress_largest_rooms(DB_URL, 7, &default_levels, 10).unwrap();
+    // Compress 4 chunks of size 8.
+    // The first two should compress room1 and the second two should compress room2
+    compress_chunks_of_database(DB_URL, 8, &default_levels, 4).unwrap();
 
     // We are aiming for the following structure in the database for room1
     // i.e. groups 6 and 9 should have changed from initial map
@@ -149,20 +148,17 @@ fn compress_largest_rooms_compresses_multiple_rooms() {
 
 #[test]
 #[serial(db)]
-fn compress_largest_rooms_does_largest_rooms() {
+fn compress_chunks_of_database_continues_where_it_left_off() {
     setup_logger();
     // This creates 2 with the following structure
     //
-    // 0-1-2 3-4-5 (room1)
-    // 14-15-16 17-18-19 20-21-22 23-24-25 26-27 (room2)
+    // 0-1-2 3-4-5 6-7-8 9-10-11 12-13
+    // (with room2's numbers shifted up 14)
     //
     // Each group i has state:
     //     ('node','is',      i)
     //     ('group',  j, 'seen') - for all j less than i in that room
-
-    // NOTE the second room has more state
-
-    let initial1 = line_segments_with_state(0, 5);
+    let initial1 = line_segments_with_state(0, 13);
     let initial2 = line_segments_with_state(14, 27);
 
     empty_database();
@@ -176,23 +172,38 @@ fn compress_largest_rooms_does_largest_rooms() {
     // compress in 3,3 level sizes by default
     let default_levels = vec![Level::new(3), Level::new(3)];
 
-    // compress the largest 1 rooms in chunks of size 7
-    // (Note this should ONLY compress room2 since it has more state)
-    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
+    // Compress chunks of various sizes:
+    //
+    // These two should compress room1
+    compress_chunks_of_database(DB_URL, 8, &default_levels, 1).unwrap();
+    compress_chunks_of_database(DB_URL, 100, &default_levels, 1).unwrap();
+    // These three should compress room2
+    compress_chunks_of_database(DB_URL, 1, &default_levels, 2).unwrap();
+    compress_chunks_of_database(DB_URL, 5, &default_levels, 1).unwrap();
+    compress_chunks_of_database(DB_URL, 5, &default_levels, 1).unwrap();
 
-    // We are aiming for the following structure in the database for room2
-    // i.e. groups 20 and 23 should have changed from initial map
+    // We are aiming for the following structure in the database for room1
+    // i.e. groups 6 and 9 should have changed from initial map
     // N.B. this saves 11 rows
     //
-    // 14  17\       26
-    // 15  18 20\    27
-    // 16  19 21 23
-    //        22 24
-    //           25
+    // 0  3\      12
+    // 1  4 6\    13
+    // 2  5 7 9
+    //      8 10
+    //        11
     //
     // Where each group i has state:
     //     ('node','is',      i)
-    //     ('group',  j, 'seen') - for all j less than i in that room
+    //     ('group',  j, 'seen') - for all j less than i
+    let expected1 = compressed_3_3_from_0_to_13_with_state();
+
+    // Check that the database still gives correct states for each group in room1
+    assert!(database_collapsed_states_match_map(&initial1));
+
+    // Check that the structure of the database matches the expected structure for room1
+    assert!(database_structure_matches_map(&expected1));
+
+    // room 2 should have the same structure but will all numbers shifted up by 14
     let expected_edges: BTreeMap<i64, i64> = vec![
         (15, 14),
         (16, 15),
@@ -211,148 +222,9 @@ fn compress_largest_rooms_does_largest_rooms() {
 
     let expected2 = structure_from_edges_with_state(expected_edges, 14, 27);
 
-    // Check that the database still gives correct states for each group in room1
-    assert!(database_collapsed_states_match_map(&initial1));
-
-    // Check that the structure of the database is still what it was initially
-    assert!(database_structure_matches_map(&initial1));
-
     // Check that the database still gives correct states for each group in room2
     assert!(database_collapsed_states_match_map(&initial2));
 
-    // Check that the structure of the database is the expected compressed one
-    assert!(database_structure_matches_map(&expected2));
-}
-
-#[test]
-#[serial(db)]
-fn compress_largest_rooms_skips_already_compressed_when_rerun() {
-    setup_logger();
-    // This test builds two rooms in the database and then calls compress_largest_rooms
-    // with a number argument of 1 (i.e. only the larger of the two rooms should be
-    // compressed)
-    //
-    // It then adds another state group to the larger of the two rooms and calls the
-    // compress_largest_rooms function again. However there is more UNCOMPRESSED state
-    // in the smaller room, so the new state added to the larger room should remain
-    // untouched
-    //
-    // This is meant to simulate events happening in rooms between calls to the function
-
-    // Initially create 2 rooms with the following structure
-    //
-    // 0-1-2 3-4-5 6-7-8 9-10-11 12-13(room1)
-    // 14-15-16 17-18-19 20 (room2)
-    //
-    // Each group i has state:
-    //     ('node','is',      i)
-    //     ('group',  j, 'seen') - for all j less than i in that room
-    // NOTE the first room is the larger one
-    let initial1 = line_segments_with_state(0, 13);
-    let initial2 = line_segments_with_state(14, 20);
-
-    empty_database();
-    add_contents_to_database("room1", &initial1);
-    add_contents_to_database("room2", &initial2);
-
-    let mut client = connect_to_database(DB_URL).unwrap();
-    create_tables_if_needed(&mut client).unwrap();
-    clear_compressor_state();
-
-    // compress in 3,3 level sizes by default
-    let default_levels = vec![Level::restore(3, 0, None), Level::restore(3, 0, None)];
-
-    // compress the largest 1 rooms in chunks of size 7
-    // (Note this should ONLY compress room1 since it has more state)
-    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
-
-    // This should have created the following structure in the database
-    // i.e. groups 6 and 9 should have changed from before
-    // N.B. this saves 11 rows
-    //
-    // 0  3\      12
-    // 1  4 6\    13
-    // 2  5 7 9
-    //      8 10
-    //        11
-    // room 2 should be unchanged
-    let expected1 = compressed_3_3_from_0_to_13_with_state();
-
-    // room1 is new structure, room2 is as it was initially
-    assert!(database_structure_matches_map(&expected1));
-    assert!(database_structure_matches_map(&initial2));
-
-    // Now add another state group to room1 with predecessor 12
-    //
-    // If the compressor is run on room1 again then the prev_state_group for 21
-    // will be set to 13
-    //
-    // i.e the compressor would try and build the following:
-    //
-    // 0  3\      12
-    // 1  4 6\    13
-    // 2  5 7 9   21
-    //      8 10
-    //        11
-
-    let mut initial1_with_new_group = expected1.clone();
-
-    let mut group21 = StateGroupEntry {
-        in_range: true,
-        prev_state_group: Some(12),
-        state_map: StateMap::new(),
-    };
-
-    // add in the new state for this state group
-    group21.state_map.insert("group", "13", "seen".into());
-    group21.state_map.insert("group", "21", "seen".into());
-    group21.state_map.insert("node", "is", "21".into());
-
-    initial1_with_new_group.insert(21, group21);
-
-    // Actually send this group to the database
-    let sql = r#"
-        INSERT INTO state_groups (id, room_id, event_id) VALUES (21,'room1','left_blank');
-        INSERT INTO state_group_edges (state_group, prev_state_group) VALUES 
-            (21,12);
-        INSERT INTO state_groups_state (state_group, room_id, type, state_key, event_id) VALUES
-            (21,'room1','node', 'is', '21'),
-            (21,'room1','group', '13', 'seen'),
-            (21,'room1','group', '21', 'seen');
-    "#;
-    client.batch_execute(sql).unwrap();
-
-    // We are aiming for the following structure in the database for room2
-    // i.e. only group 20 hould have changed from initial map
-    //
-    // 14  17\
-    // 15  18 20
-    // 16  19
-    //
-    // Where each group i has state:
-    //     ('node','is',      i)
-    //     ('group',  j, 'seen') - for all j less than i in that room
-    let expected_edges: BTreeMap<i64, i64> = vec![(15, 14), (16, 15), (18, 17), (19, 18), (20, 17)]
-        .into_iter()
-        .collect();
-
-    let expected2 = structure_from_edges_with_state(expected_edges, 14, 20);
-
-    // compress the largest 1 rooms in chunks of size 7
-    // (Note this should ONLY compress room2 since room1 only has 1 uncompressed state group)
-    compress_largest_rooms(DB_URL, 7, &default_levels, 1).unwrap();
-
-    // Check that the database still gives correct states for each group in room1
-    assert!(database_collapsed_states_match_map(
-        &initial1_with_new_group
-    ));
-
-    // Check that the structure of the database is still what it was befeore
-    // compress_largest_rooms was called (i.e. that pred of 21 is still 12 not now 13)
-    assert!(database_structure_matches_map(&initial1_with_new_group));
-
-    // Check that the database still gives correct states for each group in room2
-    assert!(database_collapsed_states_match_map(&initial2));
-    // Check that the structure of the database is the expected compressed one
+    // Check that the structure of the database matches the expected structure for room2
     assert!(database_structure_matches_map(&expected2));
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -158,6 +158,7 @@ fn load_level_heads(client: &mut Client, level_info: &[Level]) -> BTreeMap<i64, 
         LEFT JOIN state_groups_state AS s ON (m.id = s.state_group)
         LEFT JOIN state_group_edges AS e ON (m.id = e.state_group)
         WHERE m.id = ANY($1)
+        ORDER BY m.id
     "#;
 
     // Actually do the query
@@ -301,10 +302,13 @@ fn find_max_group(
     // Note a min state group is only used if groups_to_compress also is
     if min_state_group.is_some() && groups_to_compress.is_some() {
         params = vec![&room_id, &min_state_group, &groups_to_compress];
-        query_chunk_of_ids = format!(r"{} AND id > $2 LIMIT $3", query_chunk_of_ids);
+        query_chunk_of_ids = format!(
+            r"{} AND id > $2 ORDER BY id ASC LIMIT $3",
+            query_chunk_of_ids
+        );
     } else if groups_to_compress.is_some() {
         params = vec![&room_id, &groups_to_compress];
-        query_chunk_of_ids = format!(r"{} LIMIT $2", query_chunk_of_ids);
+        query_chunk_of_ids = format!(r"{} ORDER BY id ASC LIMIT $2", query_chunk_of_ids);
     } else {
         params = vec![&room_id];
     }


### PR DESCRIPTION
This is an alternative to #65 which compressed the rooms with the most uncompressed data.

This way won't work on the largest rooms first, so it might take longer to get the same space savings, but it doesn't need to count the number of rows in state_groups_state which would have taken a long time if a room hadn't been compressed before and had a lot of state.