### PR TITLE
Log to stderr not to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "env_logger 0.9.0 (git+https://github.com/TilCreator/env_logger?branch=fix_pipe)",
+ "env_logger",
  "jemallocator",
  "log",
  "log-panics",
@@ -145,7 +145,7 @@ name = "compressor_integration_tests"
 version = "0.1.0"
 dependencies = [
  "auto_compressor",
- "env_logger 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger",
  "log",
  "openssl",
  "postgres",
@@ -259,18 +259,6 @@ name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "git+https://github.com/TilCreator/env_logger?branch=fix_pipe#3d09e0d824d9301cf1c0d4a9f148f8cfeb216329"
 dependencies = [
  "atty",
  "humantime",
@@ -1139,7 +1127,7 @@ name = "synapse_compress_state"
 version = "0.1.0"
 dependencies = [
  "clap",
- "env_logger 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger",
  "indicatif",
  "jemallocator",
  "log",

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ which stores how far through the `state_groups` table the compressor has scanned
 The tool can be run manually when you are running out of space, or be scheduled to run
 periodically.
 
-The output from the auto_compressor will be sent to `auto_compressor.log` (in the directory
-that the compressor is run from).
-
 ## Building 
 
 This tool requires `cargo` to be installed. See https://www.rust-lang.org/tools/install

--- a/auto_compressor/Cargo.toml
+++ b/auto_compressor/Cargo.toml
@@ -15,7 +15,7 @@ jemallocator = "0.3.2"
 rand = "0.8.0"
 serial_test = "0.5.1"
 synapse_compress_state = { path = "../", features = ["no-progress-bars"] }
-env_logger = { version = "0.9.0", git = "https://github.com/TilCreator/env_logger", branch = "fix_pipe" }
+env_logger = "0.9.0"
 log = "0.4.14"
 log-panics = "2.0.0"
 anyhow = "1.0.42"

--- a/auto_compressor/src/main.rs
+++ b/auto_compressor/src/main.rs
@@ -37,7 +37,6 @@ fn main() {
 
     if env::var("RUST_LOG").is_err() {
         let mut log_builder = env_logger::builder();
-        log_builder.target(env_logger::Target::Pipe(Box::new(log_file)));
         // Ensure panics still come through
         log_builder.filter_module("panic", LevelFilter::Error);
         // Only output errors from the synapse_compress state library


### PR DESCRIPTION
Auto compressor for some reason was configured to log to a file. Now it just outputs to stderr.

The output can always just be piped to a file!