### PR TITLE
make jemalloc dependency really optional

### DIFF
--- a/synapse_auto_compressor/Cargo.toml
+++ b/synapse_auto_compressor/Cargo.toml
@@ -16,7 +16,6 @@ classifier = [
 openssl = "0.10.32"
 postgres = "0.19.0"
 postgres-openssl = "0.5.0"
-tikv-jemallocator = "0.5.0"
 rand = "0.8.0"
 serial_test = "0.5.1"
 synapse_compress_state = { path = "../", features = ["no-progress-bars"] }
@@ -37,3 +36,11 @@ features = ["cargo"]
 [dependencies.pyo3]
 version = "0.16.4"
 features = ["extension-module"]
+
+[dependencies.tikv-jemallocator]
+version = "0.5.0"
+optional = true
+
+[features]
+default = ["jemalloc"]
+jemalloc = ["tikv-jemallocator"]

--- a/synapse_auto_compressor/src/main.rs
+++ b/synapse_auto_compressor/src/main.rs
@@ -16,6 +16,7 @@
 //! the state_compressor_state table so that the compressor can seemlesly
 //! continue from where it left off.
 
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
this allows me to build & run on OpenBSD (`cargo build --no-default-features`), where jemalloc doesnt build as is (build failure on some linux-only cpuset structs iirc) and the default system allocator performance is sufficient.

it compressed some states but didnt shrink that much my 3gb/15m records states database, i had to drop some room history.

diff from @semarie, pushing it on his behalf.