### PR TITLE
Add CI to publish official container

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,71 @@
+# GitHub actions workflow which builds and publishes the docker images.
+
+name: Build and push docker images
+
+on:
+  push:
+    tags: ["v*"]
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Inspect builder
+        run: docker buildx inspect
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Calculate docker image tag
+        id: set-tag
+        uses: docker/metadata-action@master
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+
+      - name: Build and push all platforms
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          labels: "gitsha1=${{ github.sha }}"
+          tags: "${{ steps.set-tag.outputs.tags }}"
+          platforms: linux/amd64,linux/arm64
+
+          # arm64 builds OOM without the git fetch setting. c.f.
+          # https://github.com/rust-lang/cargo/issues/10583
+          build-args: |
+            CARGO_NET_GIT_FETCH_WITH_CLI=true
+            BUILD_PROFILE=release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM docker.io/rust:alpine AS builder
 
-RUN apk add python3 musl-dev pkgconfig openssl-dev make
+RUN apk add python3 musl-dev pkgconfig openssl-dev make git
+
+WORKDIR /opt/synapse-compressor/
+COPY . .
 
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
-WORKDIR /opt/synapse-compressor/
+# arm64 builds consume a lot of memory if `CARGO_NET_GIT_FETCH_WITH_CLI` is not
+# set to true, so we expose it as a build-arg.
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=false
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_NET_GIT_FETCH_WITH_CLI
+ARG BUILD_PROFILE=dev
 
-COPY . .
-
-RUN cargo build
+RUN cargo build --profile=$BUILD_PROFILE
 
 WORKDIR /opt/synapse-compressor/synapse_auto_compressor/
 
@@ -18,5 +23,5 @@ FROM docker.io/alpine
 
 RUN apk add --no-cache libgcc
 
-COPY --from=builder /opt/synapse-compressor/target/debug/synapse_compress_state /usr/local/bin/synapse_compress_state
-COPY --from=builder /opt/synapse-compressor/target/debug/synapse_auto_compressor /usr/local/bin/synapse_auto_compressor
+COPY --from=builder /opt/synapse-compressor/target/*/synapse_compress_state /usr/local/bin/synapse_compress_state
+COPY --from=builder /opt/synapse-compressor/target/*/synapse_auto_compressor /usr/local/bin/synapse_auto_compressor


### PR DESCRIPTION
Adds a Github Actions workflow to publish containers on merges to main and when new tags are pushed.

As part of the change, cargo will now use the release when building the published containers, but default to the dev profile when building the container locally.

To fully configure this CI pipeline, there will need to be two Github Actions secrets added:
- `DOCKERHUB_USERNAME` set to matrixdotorg
- `DOCKERHUB_TOKEN` set to an API key capable of pushing to a `matrixdotorg/rust-synapse-compress-state` Docker Hub repository

The CI will automatically start pushing to both GHCR and Docker Hub.

I've validated the CI works on my own fork of this repo. See [this job](https://github.com/thefirstofthe300/rust-synapse-compress-state/actions/runs/4974855941/jobs/8901551770) for a full run.

Signed-off-by: Danny Seymour <danny@seymour.family>