### PR TITLE
Fix README.md stating the wrong flag for levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ in) then the entire chunk is skipped.
 *CHUNKS_TO_COMPRESS* chunks of size *CHUNK_SIZE* will be compressed. The higher this
 number is set to, the longer the compressor will run for.
 
-- -d [LEVELS]
+- -l [LEVELS]
 Sizes of each new level in the compression algorithm, as a comma-separated list.
 The first entry in the list is for the lowest, most granular level, with each
 subsequent entry being for the next highest level. The number of entries in the


### PR DESCRIPTION
The README.md file states that the `-d` flag should be used to provide the size of the levels, instead, the code requires the `-l` flag https://github.com/matrix-org/rust-synapse-compress-state/blob/982ee5ead839938c90fa5d0ac871ae31393ba891/synapse_auto_compressor/src/main.rs#L91. 