### PR TITLE
Pin state-map dependency on latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "state-map"
 version = "0.1.0"
-source = "git+https://github.com/matrix-org/rust-matrix-state-map#211343e8dd8d14e8a4c5c6ab72b52589fdd37e27"
+source = "git+https://github.com/matrix-org/rust-matrix-state-map?rev=211343e#211343e8dd8d14e8a4c5c6ab72b52589fdd37e27"
 
 [[package]]
 name = "string_cache"
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "synapse_auto_compressor"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log-panics = "2.1.0"
 
 [dependencies.state-map]
 git = "https://github.com/matrix-org/rust-matrix-state-map"
+rev = "211343e"
 
 # Needed for pyo3 support
 [lib]

--- a/compressor_integration_tests/Cargo.toml
+++ b/compressor_integration_tests/Cargo.toml
@@ -19,3 +19,4 @@ log = "0.4.20"
 
 [dependencies.state-map]
 git = "https://github.com/matrix-org/rust-matrix-state-map"
+rev = "211343e"


### PR DESCRIPTION
Given how [rust-matrix-state-map](https://github.com/matrix-org/rust-matrix-state-map) hasn't had an update in six years and all other dependencies of this software are pinned, I think it's safe and a good idea to pin this version too. This will also help with packaging efforts downstream, for example in https://github.com/NixOS/nixpkgs/pull/303704.