### PR TITLE
Move python metadata to pyproject.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "synapse_auto_compressor"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/synapse_auto_compressor/Cargo.toml
+++ b/synapse_auto_compressor/Cargo.toml
@@ -8,14 +8,6 @@ edition = "2018"
 name = "synapse_auto_compressor"
 required-features = ["clap"]
 
-[package.metadata.maturin]
-requires-python = ">=3.7"
-project-url = {Source = "https://github.com/matrix-org/rust-synapse-compress-state"}
-classifier = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Rust",
-]
-
 [dependencies]
 openssl = { version = "0.10.60", features = ["vendored"] }
 postgres = "0.19.7"

--- a/synapse_auto_compressor/pyproject.toml
+++ b/synapse_auto_compressor/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "synapse_auto_compressor"
+requires-python = ">=3.7"
+classifier = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Rust",
+]
+
+[project.urls]
+Source = "https://github.com/matrix-org/rust-synapse-compress-state"
+
 [build-system]
 requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"


### PR DESCRIPTION
Otherwise maturin 1.5.0 won't let you publish.