### PR TITLE
fix: don't bail on room compression

### DIFF
--- a/synapse_auto_compressor/src/manager.rs
+++ b/synapse_auto_compressor/src/manager.rs
@@ -183,7 +183,9 @@ pub fn compress_chunks_of_database(
             }
             chunks_processed += 1;
         } else {
-            bail!("Ran the compressor on a room that had no more work to do!")
+            // Room is already fully compressed, skip to next room
+            debug!("Room {} is already fully compressed, moving to next room", room_to_compress);
+            continue;
         }
     }
     info!(


### PR DESCRIPTION
Thank you for the amazing work on this library!

## Summary

I observed this issue in one of our hosts that run `rust-synapse-compress-state`

```
× synapse-auto-compressor.service - synapse-auto-compressor
     Loaded: loaded (/etc/systemd/system/synapse-auto-compressor.service; static)
     Active: failed (Result: exit-code) since Mon 2025-05-12 00:11:01 UTC; 46s ago
TriggeredBy: ● synapse-auto-compressor.timer
       Docs: https://github.com/status-im/infra-role-systemd-timer
    Process: 1567116 ExecStart=/usr/local/bin/synapse-auto-compressor (code=exited, status=101)
   Main PID: 1567116 (code=exited, status=101)
        CPU: 7min 2.168s

[2025-05-12T00:11:01Z ERROR panic] thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Ran the compressor on a room that had no more work to do!': synapse_auto_compressor/src/main.rs:155
synapse-auto-compressor.service: Main process exited, code=exited, status=101/n/a
```

By looking at the code I observed that `run_compressor_on_room_chunk` is returning None for one of the rooms, indicating there's no more work to do in that room and I think it would be better if instead of bailing we could skip to the next room.

What do you think?