### PR TITLE
Fix docker build and set MSRV to 1.78

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,11 @@ on:
     tags: ["v*"]
     branches: [ main ]
   workflow_dispatch:
+  # Run on pull requests to test docker build.
+  # We explicitly do not push on pull requests (the job below is ended early).
+  #
+  # note: secrets will not be populated on pull requests from external authors.
+  pull_request:
 
 permissions:
   contents: read
@@ -18,19 +23,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Log in to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Calculate docker image tag
         id: set-tag
@@ -46,6 +38,25 @@ jobs:
             type=sha,prefix=,format=long
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
+      
+      - name: Don't push to registry if this is a PR
+        if: "${{ github.event_name }}" = "pull_request"
+        run: |
+          echo "Not pushing the image to any container registry as this workflow is running on a pull request"
+          exit 0
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push all platforms
         uses: docker/build-push-action@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tikv-jemallocator = "0.6.0"
 [package]
 name = "synapse_compress_state"
 description = "A tool to compress some state in a Synapse instance's database"
+rust-version = "1.78"
 authors = ["Erik Johnston"]
 version.workspace = true
 edition.workspace = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # second stage only copies the binaries for the target architecture.
 # We leverage Zig and cargo-zigbuild for providing a cross-compilation-capable C compiler and linker.
 
-ARG RUSTC_VERSION=1.72.0
-ARG ZIG_VERSION=0.11.0
-ARG CARGO_ZIGBUILD_VERSION=0.17.1
+ARG RUSTC_VERSION=1.78.0
+ARG ZIG_VERSION=0.14.1
+ARG CARGO_ZIGBUILD_VERSION=0.20.1
 
 FROM --platform=${BUILDPLATFORM} docker.io/rust:${RUSTC_VERSION} AS builder
 
@@ -15,8 +15,8 @@ RUN cargo install --locked cargo-zigbuild@=${CARGO_ZIGBUILD_VERSION}
 
 # Download zig compiler for cross-compilation
 ARG ZIG_VERSION
-RUN curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local && \
-  ln -s "/usr/local/zig-linux-$(uname -m)-${ZIG_VERSION}/zig" /usr/local/bin/zig
+RUN curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local && \
+  ln -s "/usr/local/zig-$(uname -m)-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
 
 # Install all cross-compilation targets
 ARG RUSTC_VERSION


### PR DESCRIPTION
`openssl` was failing to compile in the Dockerfile. Updating the dependencies solved it.

Rust is only updated to 1.78.0 as that's [the minimum version of `cargo` needed](https://github.com/solana-foundation/anchor/issues/3392#issuecomment-2508412018) to read our `Cargo.lock` file (which is v4).

I also set the MSRV programmatically via [`rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) in `Cargo.toml`.