### PR TITLE
Don't iterate on map

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -234,8 +234,8 @@ fn load_map_from_db(
     // we need to do this recursively until we don't find any more missing.
     loop {
         let mut missing_sgs: Vec<_> = state_group_map
-            .iter()
-            .filter_map(|(_sg, entry)| {
+            .values()
+            .filter_map(|entry| {
                 entry
                     .prev_state_group
                     .filter(|&prev_sg| !state_group_map.contains_key(&prev_sg))


### PR DESCRIPTION
Instead call `.values()` on it to filter it. Suggested by `clippy`.

`entry` ends up being a `&StateGroupEntry` in both cases, so this should be a safe change?

```
$ cargo clippy -- -D warnings
    Checking synapse_compress_state v0.1.4 (/home/jaywink/workspace/rust-synapse-compress-state)
error: iterating on a map's values
   --> src/database.rs:236:39
    |
236 |           let mut missing_sgs: Vec<_> = state_group_map
    |  _______________________________________^
237 | |             .iter()
238 | |             .filter_map(|(_sg, entry)| {
239 | |                 entry
240 | |                     .prev_state_group
241 | |                     .filter(|&prev_sg| !state_group_map.contains_key(&prev_sg))
242 | |             })
    | |______________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#iter_kv_map
    = note: `-D clippy::iter-kv-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
help: try
    |
236 ~         let mut missing_sgs: Vec<_> = state_group_map.values().filter_map(|entry| {
237 +                 entry
238 +                     .prev_state_group
239 +                     .filter(|&prev_sg| !state_group_map.contains_key(&prev_sg))
240 +             })
    |

error: could not compile `synapse_compress_state` (lib) due to 1 previous error

```