### PR TITLE
Bump MSRV to 1.80.0 in `Cargo.toml` and the `Dockerfile`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tikv-jemallocator = "0.6.0"
 [package]
 name = "synapse_compress_state"
 description = "A tool to compress some state in a Synapse instance's database"
-rust-version = "1.78"
+rust-version = "1.80"
 authors = ["Erik Johnston"]
 version.workspace = true
 edition.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tikv-jemallocator = "0.6.0"
 [package]
 name = "synapse_compress_state"
 description = "A tool to compress some state in a Synapse instance's database"
-rust-version = "1.80"
+rust-version = "1.80.0"
 authors = ["Erik Johnston"]
 version.workspace = true
 edition.workspace = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # second stage only copies the binaries for the target architecture.
 # We leverage Zig and cargo-zigbuild for providing a cross-compilation-capable C compiler and linker.
 
-ARG RUSTC_VERSION=1.78.0
+ARG RUSTC_VERSION=1.95.0
 ARG ZIG_VERSION=0.14.1
 ARG CARGO_ZIGBUILD_VERSION=0.20.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # second stage only copies the binaries for the target architecture.
 # We leverage Zig and cargo-zigbuild for providing a cross-compilation-capable C compiler and linker.
 
-ARG RUSTC_VERSION=1.95.0
+ARG RUSTC_VERSION=1.80.0
 ARG ZIG_VERSION=0.14.1
 ARG CARGO_ZIGBUILD_VERSION=0.20.1
 


### PR DESCRIPTION
https://github.com/matrix-org/rust-synapse-compress-state/pull/170 is [failing to build docker images](https://github.com/matrix-org/rust-synapse-compress-state/actions/runs/25453339680/job/76160824783?pr=170) due to requiring at least Rust 1.80 for `openssl-sys@0.9.115`.

~~Let's just bump to 1.95.0 to take advantage of the latest fixes/features.~~ We [opted](https://github.com/matrix-org/rust-synapse-compress-state/pull/171#discussion_r3251444288) to bump only to the minimum version needed to support the new openssl version.